### PR TITLE
 Fix read ECONNRESET error when closing connection on Chrome browser 

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,8 +46,8 @@ wss.on('connection', (client) => {
 });
 
 // Broadcast message to all connected clients
-wss.broadcast = function broadcast(data) {
-	wss.clients.forEach(function each(client) {
+wss.broadcast = (data) => {
+	wss.clients.forEach((client) => {
 		if (client.readyState === WebSocket.OPEN) {
 			client.send(data);
 		}

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -33,7 +33,7 @@ $(function() {
   };
 
   // Close WebSocket connection before window resources + documents are unloaded
-  window.addEventListener('beforeunload', function () {
+  window.addEventListener('beforeunload', () => {
     ws.close();
   });
 });


### PR DESCRIPTION
When closing our web page on a Chrome browser, an ECONNRESET error gets thrown and our app crashes. 

This seems to be a common issue: [https://github.com/websockets/ws/issues/1256](https://github.com/websockets/ws/issues/1256)

To get around this, I did what a commenter suggested, which was to add a [``'beforeunload'``](https://developer.mozilla.org/en-US/docs/Web/Events/beforeunload) event listener to the browser window. When triggered, the WebSocket connection gets closed. 

Also: 
-- Changed the ``ws`` variable to ``client`` in app.js for better readability
-- Error handling for WebSocket connections